### PR TITLE
mod: bump go-textile-threads version, single record per txn

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/mr-tron/base58 v1.1.2
 	github.com/multiformats/go-multiaddr v0.1.1
 	github.com/smartystreets/goconvey v0.0.0-20190710185942-9d28bd7c0945 // indirect
-	github.com/textileio/go-textile-core v0.0.0-20191205110409-5785e1750a85
-	github.com/textileio/go-textile-threads v0.0.0-20191205112930-d2645603e66e
+	github.com/textileio/go-textile-core v0.0.0-20191205233641-31fc120682c9
+	github.com/textileio/go-textile-threads v0.0.0-20191209153750-6486fa02748e
 	github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc
 	golang.org/x/sys v0.0.0-20191113165036-4c7a9d0fe056 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -495,10 +495,10 @@ github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709 h1:Ko2LQMrRU+Oy
 github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
-github.com/textileio/go-textile-core v0.0.0-20191205110409-5785e1750a85 h1:gnvpZErFp+ivAPQsXbRsqRLZA0PxPGs2cR7v6iVSLI8=
-github.com/textileio/go-textile-core v0.0.0-20191205110409-5785e1750a85/go.mod h1:zZIyxcCQ8EDdOJmv3goBIYs5nsCG/DPhNdWTEvToDWA=
-github.com/textileio/go-textile-threads v0.0.0-20191205112930-d2645603e66e h1:HwapbXbUxilhGOBZ1CadglBFY80JtkAwZ5n7gLLwPV0=
-github.com/textileio/go-textile-threads v0.0.0-20191205112930-d2645603e66e/go.mod h1:HBLSo41Tyl9k+4ipbOnpOaC2FdTrWXl8Y4z2v4250qY=
+github.com/textileio/go-textile-core v0.0.0-20191205233641-31fc120682c9 h1:DIK7mAq6K1e3H9IkKcxgNB3by3mcIrLnAS8hIZz+DYc=
+github.com/textileio/go-textile-core v0.0.0-20191205233641-31fc120682c9/go.mod h1:zZIyxcCQ8EDdOJmv3goBIYs5nsCG/DPhNdWTEvToDWA=
+github.com/textileio/go-textile-threads v0.0.0-20191209153750-6486fa02748e h1:dVgUT35CzdJNT5Sgc5Inu+Kig29JzlWvq/gZWOkH3Gk=
+github.com/textileio/go-textile-threads v0.0.0-20191209153750-6486fa02748e/go.mod h1:gAtmT18e0XJdcK5UCfUajbWP5mLjwMjnFlIdqluEF1A=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
 github.com/warpfork/go-wish v0.0.0-20190328234359-8b3e70f8e830 h1:8kxMKmKzXXL4Ru1nyhvdms/JjWt+3YLpvRb/bAjO/y0=


### PR DESCRIPTION
Bumps `go-textlie-threads` which includes [this](https://github.com/textileio/go-textile-threads/pull/156) improtant change.